### PR TITLE
Use new syntax for Application link

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/Dashboard/Applications/Evebox.php
+++ b/root/usr/share/nethesis/NethServer/Module/Dashboard/Applications/Evebox.php
@@ -39,8 +39,7 @@ class Evebox extends \Nethgui\Module\AbstractModule implements \NethServer\Modul
         $host = explode(':',$_SERVER['HTTP_HOST']);
         $alias = $configDb->getProp('evebox', 'alias');
         return array(
-            'url' => "https://".$host[0].":980/$alias",
-            'status' => $configDb->getProp('evebox', 'status')
+            'url' => "/".$alias
             );
     }
 }


### PR DESCRIPTION
This kind of links works even on ports other than 980. Useful when using ssh port forwards.
Code taken from nethserver-lightsquid
