### PR TITLE
Make sure working directory has correct permissions

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-evebox-conf
+++ b/root/etc/e-smith/events/actions/nethserver-evebox-conf
@@ -39,3 +39,6 @@ fi
 if [ ! -f /etc/evebox/GeoLite2-City.mmdb.gz ]; then
     /etc/cron.weekly/evebox-geoip
 fi
+
+# Make sure working directory has correct permissions
+chown suricata:suricata /var/lib/evebox/


### PR DESCRIPTION
This is needed when evebox rpm is updated because it changes
the directory owner to evebox:evebox

NethServer/dev#5472