### PR TITLE
Requires evebox 0.11.0

### DIFF
--- a/nethserver-evebox.spec
+++ b/nethserver-evebox.spec
@@ -8,7 +8,7 @@ Source0: %{name}-%{version}.tar.gz
 BuildArch: noarch
 
 Requires: nethserver-suricata
-Requires: evebox >= 0.10.2
+Requires: evebox >= 0.11.0
 Requires: geolite2-city
 
 BuildRequires: nethserver-devtools 


### PR DESCRIPTION
This is required to fix ownwers for /var/lib/evebox/ directory.

NethServer/dev#6101